### PR TITLE
[ROS-O] do not enforce c++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ catkin_package(
 		visualization_msgs
 )
 
-set(CMAKE_CXX_STANDARD 14)
-
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
log4cxx requires c++17 and enforcing an older standard (that is default by now) breaks it.

Required for ROS-O.